### PR TITLE
grant web3-bot access to heyfil repo

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -63,6 +63,7 @@ repositories:
       admin:
         - admin
       push:
+        - ci
         - contributors
   specs: { }
 


### PR DESCRIPTION
### Summary
This PR grants ci team push access to heyfil repository.

### Why do you need this?
web3-bot requires access to repositories where Unified CI is to be set up - https://github.com/protocol/.github/pull/417.

### What else do we need to know?
n/a

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
