### PR TITLE
Add `indexstar` and `index-observer` to management system

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -135,6 +135,87 @@ repositories:
       - ipni
     visibility: public
     vulnerability_alerts: false
+  indexstar:
+    allow_auto_merge: false
+    allow_merge_commit: true
+    allow_rebase_merge: true
+    allow_squash_merge: true
+    archived: false
+    auto_init: false
+    branch_protection:
+      main:
+        allows_deletions: false
+        allows_force_pushes: false
+        enforce_admins: false
+        require_conversation_resolution: false
+        require_signed_commits: false
+        required_linear_history: false
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          require_code_owner_reviews: false
+          required_approving_review_count: 1
+          restrict_dismissals: false
+    default_branch: main
+    delete_branch_on_merge: true
+    description: ":star: A load splitter for storetheindex :star:"
+    has_downloads: true
+    has_issues: true
+    has_projects: true
+    has_wiki: true
+    is_template: false
+    teams:
+      admin:
+        - admin
+      push:
+        - ci
+        - contributors
+    topics:
+      - routing
+      - load-balancing
+      - load-splitter
+      - storetheindex
+    visibility: public
+    vulnerability_alerts: false
+  index-observer:
+    allow_auto_merge: false
+    allow_merge_commit: true
+    allow_rebase_merge: true
+    allow_squash_merge: true
+    archived: false
+    auto_init: false
+    branch_protection:
+      main:
+        allows_deletions: false
+        allows_force_pushes: false
+        enforce_admins: false
+        require_conversation_resolution: false
+        require_signed_commits: false
+        required_linear_history: false
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          require_code_owner_reviews: false
+          required_approving_review_count: 1
+          restrict_dismissals: false
+    default_branch: main
+    delete_branch_on_merge: true
+    description: "An observability tool for storetheindex content routing systems & providers"
+    has_downloads: true
+    has_issues: true
+    has_projects: true
+    has_wiki: true
+    is_template: false
+    teams:
+      admin:
+        - admin
+      push:
+        - ci
+        - contributors
+    topics:
+      - diagnostics
+      - observability
+      - storetheindex
+    visibility: public
+    vulnerability_alerts: false
   specs:
     allow_auto_merge: false
     allow_merge_commit: true


### PR DESCRIPTION


### Summary
Add `indexstar` and `index-observer` to the list of repos managed.

### Why do you need this?

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
