### PR TITLE
Give contributors access to `go-indexer-core`

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -128,6 +128,12 @@ repositories:
     has_projects: true
     has_wiki: true
     is_template: false
+    teams:
+      admin:
+        - admin
+      push:
+        - ci
+        - contributors
     visibility: public
     vulnerability_alerts: true
   heyfil:


### PR DESCRIPTION


### Summary
Give contributors push access to `go-indexer-core`. While at it adjust other teams access.

### Why do you need this?
To give @ischasny write access

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
