### PR TITLE
Give team access to push to `dhstore`

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -75,6 +75,12 @@ repositories:
     has_projects: true
     has_wiki: true
     is_template: false
+    teams:
+      admin:
+        - admin
+      push:
+        - ci
+        - contributors
     visibility: public
     vulnerability_alerts: true
   github-mgmt:


### PR DESCRIPTION


### Summary
Configure typical team settings for `dhstore` repo

### Why do you need this?
So that the team can write to the repo.


**DRI:** myself
@masih

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
