### PR TITLE
Add `ipni/lookout` with default permissions

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -535,8 +535,8 @@ repositories:
         - contributors
     topics:
       - diagnostics
-      - lookup
       - ipni
+      - lookup
     visibility: public
     vulnerability_alerts: true
   specs:

--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -506,14 +506,37 @@ repositories:
     allow_squash_merge: true
     archived: false
     auto_init: false
+    branch_protection:
+      main:
+        allows_deletions: false
+        allows_force_pushes: false
+        enforce_admins: false
+        require_conversation_resolution: false
+        require_signed_commits: false
+        required_linear_history: false
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          require_code_owner_reviews: false
+          required_approving_review_count: 1
+          restrict_dismissals: false
     default_branch: main
-    delete_branch_on_merge: false
-    description: On the lookout for IPNI lookup coverage
+    delete_branch_on_merge: true
+    description: ":telescope: On the lookout for lookup quality"
     has_downloads: true
     has_issues: true
     has_projects: true
     has_wiki: true
     is_template: false
+    teams:
+      admin:
+        - admin
+      push:
+        - ci
+        - contributors
+    topics:
+      - diagnostics
+      - lookup
+      - ipni
     visibility: public
     vulnerability_alerts: true
   specs:


### PR DESCRIPTION


### Summary
Add `ipni/lookout` with default permissions

See:
 - https://github.com/ipni/lookout

### Why do you need this?
Configure default permissions for the new repo.

### What else do we need to know?

**DRI:** myself
@masih

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
