### PR TITLE
Allow contributors to push to dhfind

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -214,6 +214,7 @@ repositories:
     teams:
       push:
         - ci
+        - contributors
     visibility: public
     vulnerability_alerts: true
   dhstore:


### PR DESCRIPTION
### Summary
Contributors should be able to push to dhfind repo.

### Why do you need this?
Do that ipni contributors can create branches for PRs in this repo.

### What else do we need to know?
I am an ipni contributor and need to make changes in dhfind

### Reviewer's Checklist
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
