### PR TITLE
Add go-ipni-cli github repo

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -374,6 +374,42 @@ repositories:
         - contributors
     visibility: public
     vulnerability_alerts: true
+  go-ipni-cli:
+    allow_auto_merge: false
+    allow_merge_commit: true
+    allow_rebase_merge: true
+    allow_squash_merge: true
+    archived: false
+    auto_init: false
+    branch_protection:
+      main:
+        allows_deletions: false
+        allows_force_pushes: false
+        enforce_admins: false
+        require_conversation_resolution: false
+        require_signed_commits: false
+        required_linear_history: false
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          require_code_owner_reviews: false
+          required_approving_review_count: 1
+          restrict_dismissals: false
+    default_branch: main
+    delete_branch_on_merge: true
+    description: IPNI command line interface in Go
+    has_downloads: true
+    has_issues: true
+    has_projects: true
+    has_wiki: true
+    is_template: false
+    teams:
+      admin:
+        - admin
+      push:
+        - ci
+        - contributors
+    visibility: public
+    vulnerability_alerts: true
   go-libipni:
     allow_auto_merge: false
     allow_merge_commit: true


### PR DESCRIPTION
### Summary
Ad a new repo: `go-ipni-cli`. This repository will create a command line interface executable that interacts with IPNI indexers and index providers. Its `command` package is used to construct the cli executable, and can also be imported into other projects that want to implement those same commands.

### Why do you need this?
1. To provide a stand-alone CLI that can be built outside of storetheindex and index-provider.
2. To remove redundant implementations of the same command in multiple projects.

### What else do we need to know?
nothing

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
