### PR TITLE
Make gammazero an IPNI maintainer

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -1755,10 +1755,10 @@ teams:
       maintainer:
         - davidd8
         - galargh
+        - gammazero
         - masih
         - willscott
       member:
-        - gammazero
         - honghaoq
         - ischasny
         - jennijuju


### PR DESCRIPTION
### Summary
Change gammazero from IPNI member to maintainer

### Why do you need this?
gammazero does maintenance work on many of the repos within IPNI and needs permission to do things when necessary, that would otherwise require a maintainer

### What else do we need to know?
N/A

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
