### PR TITLE
need to override review requirement for small changes

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -531,6 +531,8 @@ repositories:
         required_linear_history: false
         required_pull_request_reviews:
           dismiss_stale_reviews: false
+          pull_request_bypassers:
+            - MDQ6VXNlcjExNzkwNzg5 # gammazero
           require_code_owner_reviews: false
           required_approving_review_count: 1
           restrict_dismissals: false


### PR DESCRIPTION
### Summary
gammazero needs to merge small changes without review, generally for the purpose of deploying a new version

### Why do you need this?
For updating the version in prep for deployment, or to merge trivial changes, without having to wait for another maintainer (generally in a different timezone) to have to approve.

### What else do we need to know?
N/A

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
