### PR TITLE
Allow bypass review for emergency deploy if needed

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -1182,6 +1182,8 @@ repositories:
         required_linear_history: false
         required_pull_request_reviews:
           dismiss_stale_reviews: false
+          pull_request_bypassers:
+            - MDQ6VXNlcjExNzkwNzg5 # gammazero
           require_code_owner_reviews: false
           required_approving_review_count: 1
           restrict_dismissals: false


### PR DESCRIPTION
### Summary
Allow gammazero to bypass review for indexstar PR merge.

### Why do you need this?
Sometimes it is necessary to make time-sensitive fixes to indexstar and deploy these quickly, sometimes when no one else is immediately available for review.

### What else do we need to know?
N/A

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
