### PR TITLE
Archive the dhfind repo

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -453,7 +453,7 @@ repositories:
     allow_rebase_merge: true
     allow_squash_merge: true
     allow_update_branch: false
-    archived: false
+    archived: true
     auto_init: false
     branch_protection:
       main:


### PR DESCRIPTION
### Summary
Now that dhfind functionality is included with dhstore, the code in the `dhfind` repo is no longer needed.

### Why do you need this?
To let people know that dhfind is not being maintained, and that it should not be used in an IPNI deployment.

### What else do we need to know?
N/A

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
