### PR TITLE
Allow IPNI contributors to push to go-naam

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -924,6 +924,7 @@ repositories:
     teams:
       push:
         - ci
+        - contributors
     visibility: public
     vulnerability_alerts: true
   herald:


### PR DESCRIPTION
### Summary
Allow IPNI contributors to push to the `go-naam` repo.

### Why do you need this?
Want to submit PRs to go-naam.

### What else do we need to know?
N/A

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
