### PR TITLE
Allow gammazero to force-push to depute repo

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -382,6 +382,8 @@ repositories:
         required_linear_history: false
         required_pull_request_reviews:
           dismiss_stale_reviews: false
+          pull_request_bypassers:
+            - MDQ6VXNlcjExNzkwNzg5 # gammazero
           require_code_owner_reviews: false
           required_approving_review_count: 1
           restrict_dismissals: false


### PR DESCRIPTION
### Summary
Allow gammazero to force-push to depute repo

### Why do you need this?
To make changes that do not need review

### What else do we need to know?
**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
