### PR TITLE
Temporarily allow destroying repo

### DIFF
--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -102,7 +102,7 @@ resource "github_repository" "this" {
 
   lifecycle {
     ignore_changes  = []
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }
 


### PR DESCRIPTION
### Summary
Temporarily allow destroying repo

### Why do you need this?
Need to delete repo that no one is using.
