### PR TITLE
Re-enable prevent destroy

### DIFF
--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -102,7 +102,7 @@ resource "github_repository" "this" {
 
   lifecycle {
     ignore_changes  = []
-    prevent_destroy = false
+    prevent_destroy = true
   }
 }
 


### PR DESCRIPTION
### Summary
Re-enable prevent destroy

### Why do you need this?
This was temproarily disable to remove unused test repo. Reenabling now.
