### PR TITLE
give contributors push access to relayx

### DIFF
--- a/github/ipni.yml
+++ b/github/ipni.yml
@@ -1735,6 +1735,12 @@ repositories:
     secret_scanning: true
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    teams:
+      admin:
+        - admin
+      push:
+        - ci
+        - contributors
     visibility: public
     vulnerability_alerts: true
   roadmap:


### PR DESCRIPTION
### Summary
ive contributors and CI push access to relayx

### Why do you need this?
To create branches for PRs

### What else do we need to know?
nothing

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
